### PR TITLE
fix: oauthScopes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ To use with a custom host, eg. `gitlab.example.com`:
 
 ```sh
 git config --global credential.https://gitlab.example.com.oauthClientId <CLIENTID>
-git config --global credential.https://gitlab.example.com.oauthScopes read_repository write_repository
+git config --global credential.https://gitlab.example.com.oauthScopes 'read_repository write_repository'
 git config --global credential.https://gitlab.example.com.oauthAuthURL /oauth/authorize
 git config --global credential.https://gitlab.example.com.oauthTokenURL /oauth/token
 git config --global credential.https://gitlab.example.com.oauthDeviceAuthURL /oauth/authorize_device


### PR DESCRIPTION
The quotes are missing for oauthScopes leading to read-only permissions, instead of read-write.

This will probably save some people a few minutes of debugging.