### PR TITLE
Provide oauthClientId in a file

### DIFF
--- a/main.go
+++ b/main.go
@@ -236,10 +236,22 @@ func main() {
 		}
 		gitPath, err := exec.LookPath("git")
 		if err == nil {
-			cmd := exec.Command(gitPath, "config", "--get-urlmatch", "credential.oauthClientId", urll)
+			// Use oauthClientIdFile first. If it's not found, fall back to oauthClientId
+			cmd := exec.Command(gitPath, "config", "--get-urlmatch", "credential.oauthClientIdFile", urll)
 			bytes, err := cmd.Output()
 			if err == nil {
+				var oauthClientIdFile = strings.TrimSpace(string(bytes))
+				bytes, err := os.ReadFile(oauthClientIdFile)
+				if err != nil {
+					log.Fatalln(err)
+				}
 				c.ClientID = strings.TrimSpace(string(bytes))
+			} else {
+				cmd := exec.Command(gitPath, "config", "--get-urlmatch", "credential.oauthClientId", urll)
+				bytes, err := cmd.Output()
+				if err == nil {
+					c.ClientID = strings.TrimSpace(string(bytes))
+				}
 			}
 			bytes, err = exec.Command(gitPath, "config", "--get-urlmatch", "credential.oauthClientSecret", urll).Output()
 			if err == nil {


### PR DESCRIPTION
This patch allows the user to configure a filename containing the value for oauthClientId. That would allow an easier handling of encrypted secrets with tools like agenix or git-crypt.