### PR TITLE
add dark/light mode to the succes page

### DIFF
--- a/main.go
+++ b/main.go
@@ -401,6 +401,7 @@ var template string = `<!DOCTYPE html>
 <html lang="en">
 <head>
 	<title>Git authentication</title>
+	<meta name="color-scheme" content="light dark">
 </head>
 <body>
 <p>Success. You may close this page and return to Git.</p>


### PR DESCRIPTION
This single line insert is the simplest way to make the success page respect the system colour theme