### PR TITLE
use strings.Cut to parse input

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,9 +133,7 @@ func parse(input string) map[string]string {
 	lines := strings.Split(string(input), "\n")
 	pairs := map[string]string{}
 	for _, line := range lines {
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) >= 2 {
-			key, value := parts[0], parts[1]
+		if key, value, ok := strings.Cut(line, "="); ok {
 			_, exists := pairs[key]
 			if strings.HasSuffix(key, "[]") && exists {
 				pairs[key] += "\n" + value


### PR DESCRIPTION
Go 1.18 added `strings.Cut()` to split strings into two pieces. We can use it in `parse()` to replace `strings.SplitN(..., 2)`