### PR TITLE
Add support for proxy in git config

### DIFF
--- a/main.go
+++ b/main.go
@@ -280,6 +280,25 @@ func main() {
 			if err == nil {
 				c.RedirectURL = strings.TrimSpace(string(bytes))
 			}
+			bytes, err = exec.Command(gitPath, "config", "--get-urlmatch", "http.proxy", urll).Output()
+			if err == nil {
+				proxyStr := strings.TrimSpace(string(bytes))
+				if !(strings.HasPrefix(proxyStr, "http://") || strings.HasPrefix(proxyStr, "https://")) {
+					proxyStr = "http://" + proxyStr
+				}
+				if verbose {
+					fmt.Fprintln(os.Stderr, "proxy:", proxyStr)
+				}
+				proxy, err := url.Parse(proxyStr)
+				if err == nil {
+					httpClient := &http.Client{
+						Transport: &http.Transport{
+							Proxy: http.ProxyURL(proxy),
+						},
+					}
+					ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
+				}
+			}
 		}
 		if c.ClientID == "" || c.Endpoint.AuthURL == "" || c.Endpoint.TokenURL == "" {
 			if looksLikeGitLab {


### PR DESCRIPTION
I have configured proxy in .gitconfig but git-credentials-oauth do not take it into account.
http(s)_proxy env variable is not an option as it's not global proxy but just proxy to access git servers.

I added support to read http.proxy for specific url in git-credentials-oauth and it works like a charm for me.