### PR TITLE
Added forceful bearer support to custom hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ git config --global credential.https://gitlab.example.com.oauthDeviceAuthURL /oa
 2. Consult the documentation for OAuth scopes and URLs.
 2. Adjust the config commands below with the generated client id, OAuth scopes and relative URLs.
 3. Share the config commands with colleagues so they can skip the registration step.
+4. If using bearer authentication, then the flag `-bearer` must also be set. For example `oauth -bearer`. Without this the credential
+   will be passed to git as a username/password pair and wrapped in basic authentication.
 
 ```sh
 git config --global credential.https://code.example.com.oauthClientId <CLIENTID>
@@ -183,6 +185,7 @@ git config --global credential.https://code.example.com.oauthScopes "read_reposi
 git config --global credential.https://code.example.com.oauthAuthURL /oauth/authorize
 git config --global credential.https://code.example.com.oauthTokenURL /oauth/token
 git config --global credential.https://code.example.com.oauthDeviceAuthURL /oauth/authorize_device
+git config --global credential.https://code.example.com.useBearer "true"
 ```
 
 ## Philosophy

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"os/exec"
 	"runtime"
 	"runtime/debug"
+	"strconv"
 	"strings"
 
 	"golang.org/x/oauth2"
@@ -190,6 +191,7 @@ func main() {
 	}
 	switch args[0] {
 	case "get":
+		var useBearer = false
 		if verbose {
 			printVersion(os.Stderr)
 		}
@@ -280,6 +282,13 @@ func main() {
 			if err == nil {
 				c.RedirectURL = strings.TrimSpace(string(bytes))
 			}
+			bytes, err = exec.Command(gitPath, "config", "--get-urlmatch", "credential.useBearer", urll).Output()
+			if err == nil {
+				useBearer, err = strconv.ParseBool(strings.TrimSpace(string(bytes)))
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Failed to parse 'credential.useBearer' as boolean, ignoring")
+				}
+			}
 		}
 		if c.ClientID == "" || c.Endpoint.AuthURL == "" || c.Endpoint.TokenURL == "" {
 			if looksLikeGitLab {
@@ -335,7 +344,7 @@ func main() {
 		// "A capability[] directive must precede any value depending on it and these directives should be the first item announced in the protocol." https://git-scm.com/docs/git-credential
 		fmt.Println("capability[]=authtype")
 		output := make(map[string]string, 5)
-		hostSupportsBearer := host == "bitbucket.org" || host == "codeberg.org" || host == "gitea.com" || looksLikeGitea || strings.HasSuffix(host, ".googlesource.com")
+		hostSupportsBearer := useBearer || host == "bitbucket.org" || host == "codeberg.org" || host == "gitea.com" || looksLikeGitea || strings.HasSuffix(host, ".googlesource.com")
 		authtypeCapable := strings.Contains(pairs["capability[]"], "authtype")
 		if bearer && hostSupportsBearer && authtypeCapable {
 			output["authtype"] = "Bearer"


### PR DESCRIPTION
Added a flag to force the use of bearer tokens for custom hosts. This is because by default, the token is wrapped in a username/password basic auth header, which is troublesome for custom hosts to handle.