### PR TITLE
Kill last callback server if fixed callback port is used

### DIFF
--- a/main.go
+++ b/main.go
@@ -448,9 +448,16 @@ func getToken(ctx context.Context, c oauth2.Config, authURLSuffix string) (*oaut
 			log.Fatalln(err)
 		}
 		origHostname := url.Hostname()
+		if port := url.Port(); port != "" && runtime.GOOS == "linux" {
+			if verbose {
+				fmt.Fprintf(os.Stderr, "killing existing server on port %s\n", port)
+			}
+			exec.Command("fuser", "-k", port+"/tcp").Run()
+		}
 		if url.Port() == "" {
 			url.Host += ":0"
 		}
+
 		l, err := net.Listen("tcp", url.Host)
 		if err != nil {
 			log.Fatalln(err)


### PR DESCRIPTION
This change attempts to kill the last running callback instance before starting a new one. This helps avoid the dangling callback server if the user cancelled the last operation and a fixed redirectURL is used (i.e. for public portforwarding).