### PR TITLE
feat: allow oauth* config values to be shell commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,23 @@ git config --global credential.https://code.example.com.oauthTokenURL /oauth/tok
 git config --global credential.https://code.example.com.oauthDeviceAuthURL /oauth/authorize_device
 ```
 
+### Dynamic values from a shell command
+
+Any `oauth*` config value may be wrapped in backticks to have its content executed as a shell command; the trimmed
+STDOUT is used as the effective value. This lets you source secrets from a password manager (or any other tool) instead
+of committing them to `~/.gitconfig` in plaintext.
+
+```ini
+[credential "https://some-site.com"]
+	helper            = oauth
+	oauthClientId     = `pass show secret/some-site.com/oauth-client-secret | jq -r .id`
+	oauthClientSecret = `pass show secret/some-site.com/oauth-client-secret | jq -r .secret`
+```
+
+Commands run via `$SHELL` (fallback `/bin/sh`) on Unix and `%COMSPEC%` (fallback `cmd.exe`) on Windows, so pipes and
+other shell features are supported. Only the `oauth*` keys read by this helper are evaluated; other Git config values
+are untouched.
+
 ## Philosophy
 
 * Do one thing well, namely OAuth authentication.

--- a/main.go
+++ b/main.go
@@ -245,40 +245,65 @@ func main() {
 			cmd := exec.Command(gitPath, "config", "--get-urlmatch", "credential.oauthClientId", urll)
 			bytes, err := cmd.Output()
 			if err == nil {
-				c.ClientID = strings.TrimSpace(string(bytes))
+				c.ClientID, err = evalConfigValue(string(bytes))
+				if err != nil {
+					log.Fatalln(err)
+				}
 			}
 			bytes, err = exec.Command(gitPath, "config", "--get-urlmatch", "credential.oauthClientSecret", urll).Output()
 			if err == nil {
-				c.ClientSecret = strings.TrimSpace(string(bytes))
+				c.ClientSecret, err = evalConfigValue(string(bytes))
+				if err != nil {
+					log.Fatalln(err)
+				}
 			}
 			bytes, err = exec.Command(gitPath, "config", "--get-urlmatch", "credential.oauthScopes", urll).Output()
 			if err == nil {
-				c.Scopes = []string{strings.TrimSpace(string(bytes))}
+				scope, err := evalConfigValue(string(bytes))
+				if err != nil {
+					log.Fatalln(err)
+				}
+				c.Scopes = []string{scope}
 			}
 			bytes, err = exec.Command(gitPath, "config", "--get-urlmatch", "credential.oauthAuthURL", urll).Output()
 			if err == nil {
-				c.Endpoint.AuthURL, err = urlResolveReference(urll, strings.TrimSpace(string(bytes)))
+				value, err := evalConfigValue(string(bytes))
+				if err != nil {
+					log.Fatalln(err)
+				}
+				c.Endpoint.AuthURL, err = urlResolveReference(urll, value)
 				if err != nil {
 					log.Fatalln(err)
 				}
 			}
 			bytes, err = exec.Command(gitPath, "config", "--get-urlmatch", "credential.oauthTokenURL", urll).Output()
 			if err == nil {
-				c.Endpoint.TokenURL, err = urlResolveReference(urll, strings.TrimSpace(string(bytes)))
+				value, err := evalConfigValue(string(bytes))
+				if err != nil {
+					log.Fatalln(err)
+				}
+				c.Endpoint.TokenURL, err = urlResolveReference(urll, value)
 				if err != nil {
 					log.Fatalln(err)
 				}
 			}
 			bytes, err = exec.Command(gitPath, "config", "--get-urlmatch", "credential.oauthDeviceAuthURL", urll).Output()
 			if err == nil {
-				c.Endpoint.DeviceAuthURL, err = urlResolveReference(urll, strings.TrimSpace(string(bytes)))
+				value, err := evalConfigValue(string(bytes))
+				if err != nil {
+					log.Fatalln(err)
+				}
+				c.Endpoint.DeviceAuthURL, err = urlResolveReference(urll, value)
 				if err != nil {
 					log.Fatalln(err)
 				}
 			}
 			bytes, err = exec.Command(gitPath, "config", "--get-urlmatch", "credential.oauthRedirectURL", urll).Output()
 			if err == nil {
-				c.RedirectURL = strings.TrimSpace(string(bytes))
+				c.RedirectURL, err = evalConfigValue(string(bytes))
+				if err != nil {
+					log.Fatalln(err)
+				}
 			}
 		}
 		if c.ClientID == "" || c.Endpoint.AuthURL == "" || c.Endpoint.TokenURL == "" {
@@ -571,6 +596,51 @@ func replaceHostInURL(originalURL, host string) string {
 	}
 	u.Host = host
 	return u.String()
+}
+
+// if the value is wrapped in backticks, the inner string is executed via the user's shell and its trimmed STDOUT is
+// returned instead. Lets a git config value source secrets from a password manager via a pipeline (e.g. `pass show foo
+// | head -1`).
+func evalConfigValue(raw string) (string, error) {
+	v := strings.TrimSpace(raw)
+	if len(v) < 2 || !strings.HasPrefix(v, "`") || !strings.HasSuffix(v, "`") {
+		return v, nil
+	}
+	script := v[1 : len(v)-1]
+	if verbose {
+		fmt.Fprintf(os.Stderr, "evaluating config command: %s\n", script)
+	}
+	out, err := runInShell(script)
+	if err != nil {
+		return "", fmt.Errorf("evaluating config command %q: %w", script, err)
+	}
+	return out, nil
+}
+
+// executes script through the user's default shell and returns trimmed STDOUT.
+// On Unix it uses $SHELL (fallback /bin/sh)
+// On Windows it uses %COMSPEC% (fallback cmd.exe).
+func runInShell(script string) (string, error) {
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		shell := os.Getenv("COMSPEC")
+		if shell == "" {
+			shell = "cmd.exe"
+		}
+		cmd = exec.Command(shell, "/C", script)
+	} else {
+		shell := os.Getenv("SHELL")
+		if shell == "" {
+			shell = "/bin/sh"
+		}
+		cmd = exec.Command(shell, "-c", script)
+	}
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 func urlResolveReference(base, ref string) (string, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -30,6 +31,76 @@ func TestQR(t *testing.T) {
 	}
 	if err := writeQRCode(os.Stdout, msg); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestEvalConfigValuePlain(t *testing.T) {
+	tests := map[string]string{
+		"":                "",
+		"   ":             "",
+		"plain":           "plain",
+		"  padded  ":      "padded",
+		"has `backtick` in middle":     "has `backtick` in middle",
+		"`only-open":                   "`only-open",
+		"only-close`":                  "only-close`",
+		"`":                            "`",
+	}
+	for input, want := range tests {
+		got, err := evalConfigValue(input)
+		if err != nil {
+			t.Errorf("evalConfigValue(%q) error: %v", input, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("evalConfigValue(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestEvalConfigValueShell(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell syntax; skipping on Windows")
+	}
+	tests := map[string]string{
+		"`echo hello`":                    "hello",
+		"  `echo hello`  ":                "hello",
+		"`printf 'secret\\n' | head -1`":  "secret",
+		"`echo one; echo two`":            "one\ntwo",
+		"``":                              "",
+	}
+	for input, want := range tests {
+		got, err := evalConfigValue(input)
+		if err != nil {
+			t.Errorf("evalConfigValue(%q) error: %v", input, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("evalConfigValue(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestEvalConfigValueShellError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell syntax; skipping on Windows")
+	}
+	_, err := evalConfigValue("`exit 3`")
+	if err == nil {
+		t.Fatal("expected error from failing shell command, got nil")
+	}
+}
+
+func TestEvalConfigValueRespectsSHELL(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell syntax; skipping on Windows")
+	}
+	t.Setenv("SHELL", "/bin/sh")
+	got, err := evalConfigValue("`echo via-sh`")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "via-sh" {
+		t.Errorf("got %q, want %q", got, "via-sh")
 	}
 }
 


### PR DESCRIPTION
Any `credential.<url>.oauth*` value wrapped in backticks is now executed via the user's default shell (`$SHELL` on Unix, `%COMSPEC%` on Windows, with `/bin/sh` and `cmd.exe` as fallbacks) and its trimmed STDOUT is used in place of the literal value.

Motivation: OAuth client secrets sitting plaintext in `~/.gitconfig` are awkward to protect. This lets users source them from a password manager or keychain via a pipeline, e.g.

    oauthClientSecret = `pass show secret/some-site.com/oauth-client-secret | head -1`

Only the `oauth*` keys this helper reads are evaluated; other git config values are untouched. Pipes and other shell features are supported since execution goes through the shell rather than a direct exec.